### PR TITLE
Fix Sidebar Navigation Arrow

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -137,5 +137,15 @@
 
   @media (min-width: breakpoint.$desktop) {
     display: flex;
+    display: inline-block; /* Ensure the element can be transformed */
+    transition: transform 0.3s ease; /* Optional: adds a smooth transition */
+  }
+
+  &.isCollapsed {
+    @media (min-width: breakpoint.$desktop) {
+      img {
+        transform: rotate(180deg);
+      }
+    }
   }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isCollapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
What this does:

- This PR addresses a bug on the sidebar navigation 
  - see: https://profy.dev/project/react-job-simulator/board?task=fix-sidebar-navigation-arrow
- Before: When selecting "collapse", the sidebar collapses but the arrow continues to point to the left
  - ![image](https://github.com/profydev/prolog-app-cameronamini/assets/66532643/37f85510-57d7-4686-becc-2752d2d826db)

- After: After sidebar collapses, arrow points to the right
  - ![image](https://github.com/profydev/prolog-app-cameronamini/assets/66532643/1e4e29da-1704-4ade-ad6a-c5ff6fdca014)


Implementation:
- Modified css module so a transition is applied when css classNames "collapseMenuItem" and "isCollapsed" both apply 

