### PR TITLE
fix: change logo when switching to mobile

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -35,15 +35,28 @@ export function SidebarNavigation() {
       >
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
-            alt="logo"
-            className={styles.logo}
-          />
+          <picture className={styles.logo}>
+            <source
+              media="(min-width: 1024px)"
+              srcSet={
+                isSidebarCollapsed
+                  ? "/icons/logo-small.svg"
+                  : "/icons/logo-large.svg"
+              }
+            />
+            <source
+              media="(max-width: 1024px)"
+              srcSet="/icons/logo-small.svg"
+            />
+            <img
+              alt="logo"
+              src={
+                isSidebarCollapsed
+                  ? "/icons/logo-small.svg"
+                  : "/icons/logo-large.svg"
+              }
+            />
+          </picture>
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
             className={styles.menuButton}


### PR DESCRIPTION
# Description

This fixes a bug when switching to mobile view in the app. 


To fix the issue, the code was modified such that only the full logo would be shown when in mobile view. This was accomplished using the picture and source elements, which allow specifying an image source for given screen dimensions. 


Fixes "Sidebar Navigation: Wrong logo when switching to mobile view"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified using manual testing. To reproduce original bug: on main branch, on desktop view collapse sidebar, and then shrink window to mobile size. To verify fix, repeat this process on this branch.
