### PR TITLE
fix: project card badge styling

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -9,6 +9,11 @@ export enum ProjectStatus {
   warning = "warning",
   critical = "critical",
 }
+export enum APIProjectStatus {
+  info = "info",
+  warning = "warning",
+  error = "error",
+}
 
 export type Project = {
   id: string;
@@ -16,5 +21,5 @@ export type Project = {
   language: ProjectLanguage;
   numIssues: number;
   numEvents24h: number;
-  status: ProjectStatus;
+  status: APIProjectStatus;
 };

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,6 +1,13 @@
 import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
 
+const mockDisplayStatusValues = {
+  info: "stable",
+  warning: "warning",
+  error: "critical",
+};
+type Status = keyof typeof mockDisplayStatusValues;
+
 describe("Project List", () => {
   beforeEach(() => {
     // setup request mock
@@ -32,7 +39,12 @@ describe("Project List", () => {
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+
+          cy.wrap($el).contains(
+            capitalize(
+              mockDisplayStatusValues[mockProjects[index].status as Status],
+            ),
+          );
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Meta, StoryFn } from "@storybook/react";
 import { ProjectCard } from "./project-card";
-import { ProjectLanguage, ProjectStatus } from "@api/projects.types";
+import { ProjectLanguage, APIProjectStatus } from "@api/projects.types";
 
 export default {
   title: "Project/ProjectCard",
@@ -33,7 +33,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: APIProjectStatus.error,
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -2,7 +2,11 @@ import Link from "next/link";
 import capitalize from "lodash/capitalize";
 import { Badge, BadgeColor } from "@features/ui";
 import { Routes } from "@config/routes";
-import { ProjectLanguage, ProjectStatus } from "@api/projects.types";
+import {
+  ProjectLanguage,
+  ProjectStatus,
+  APIProjectStatus,
+} from "@api/projects.types";
 import type { Project } from "@api/projects.types";
 import styles from "./project-card.module.scss";
 
@@ -16,6 +20,13 @@ const languageNames = {
   [ProjectLanguage.python]: "Python",
 };
 
+const displayStatusValues = {
+  //APIProjectStatus is the status from the API, ProjectStatus is the status we want to display
+  [APIProjectStatus.info]: ProjectStatus.stable,
+  [APIProjectStatus.warning]: ProjectStatus.warning,
+  [APIProjectStatus.error]: ProjectStatus.critical,
+};
+
 const statusColors = {
   [ProjectStatus.stable]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
@@ -24,6 +35,7 @@ const statusColors = {
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const { name, language, numIssues, numEvents24h, status } = project;
+  const displayStatus = displayStatusValues[status];
 
   return (
     <div className={styles.container}>
@@ -50,7 +62,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <div className={styles.issuesNumber}>{numEvents24h}</div>
           </div>
           <div className={styles.status}>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[displayStatus]}>
+              {capitalize(displayStatus)}
+            </Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Description

This change updates the styling of the project card status badges on the projects page to match with specified designs. 

Fixes issue ["Project list doesn’t show correct status"](https://profy.dev/project/react-job-simulator/board?task=project-list-incorrect-status)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This change has been tested with: 

- [x] Manual testing
- [x] Cypress testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules